### PR TITLE
Plot3d review

### DIFF
--- a/silx/gui/plot3d/Plot3DActions.py
+++ b/silx/gui/plot3d/Plot3DActions.py
@@ -297,6 +297,7 @@ class VideoAction(Plot3DAction):
         """Save video as MNG file.
 
         :param str filename: filename to use
+        :param int nbFrames: Number of frames to generate
         """
         plot3d = self.getPlot3DWidget()
         assert plot3d is not None

--- a/silx/gui/plot3d/SFViewParamTree.py
+++ b/silx/gui/plot3d/SFViewParamTree.py
@@ -100,10 +100,9 @@ class SubjectItem(qt.QStandardItem):
         This is useful to let this method know if the setData method was called
         internaly or from the view.
 
-        :param value:
-        :param role:
-        :param pushData:
-        :return:
+        :param value: the value ti set to data
+        :param role: role in the item
+        :param pushData: if True push value in the existing data.
         """
         if role == qt.Qt.EditRole and pushData:
             setValue = self._pushData(value, role)
@@ -164,8 +163,7 @@ class SubjectItem(qt.QStandardItem):
         Set the enabled state for this cell, or for the whole row
         if this item has a parent.
 
-        :param enable:
-        :return:
+        :param bool enable: True if we wan't to enable the cell
         """
         parent = self.parent()
         model = self.model()
@@ -238,7 +236,7 @@ class SubjectItem(qt.QStandardItem):
         Returns the editor widget used to edit this item's data. The arguments
         are the one passed to the QStyledItemDelegate.createEditor method.
 
-        :param parent:
+        :param parent: the Qt parent of the editor
         :param option:
         :param index:
         :return:
@@ -1184,8 +1182,7 @@ class TreeView(qt.QTreeView):
         """
         Sets the ScalarFieldView this view is controlling.
 
-        :param sfView:
-        :return:
+        :param sfView: the ScalarFieldView to control
         """
         model = qt.QStandardItemModel()
         model.setColumnCount(ModelColumns.ColumnMax)
@@ -1279,9 +1276,9 @@ class TreeView(qt.QTreeView):
         Reimplementation of the QTreeView.rowsAboutToBeRemoved. Closes all
         persistend editors under parent.
 
-        :param parent:
-        :param start:
-        :param end:
+        :param parent: the parent item
+        :param start: start item to be removed (inclusive)
+        :param end: end item to be removed (inclusive)
         """
         self.__openPersistentEditors(parent, False)
         super(TreeView, self).rowsAboutToBeRemoved(parent, start, end)
@@ -1291,9 +1288,9 @@ class TreeView(qt.QTreeView):
         Called when QTreeView.rowsRemoved is emitted. Opens all persistent
         editors under parent.
 
-        :param parent:
-        :param start:
-        :param end:
+        :param parent: the parent item
+        :param start: start item to be removed (inclusive)
+        :param end: end item to be removed (inclusive)
         :return:
         """
         super(TreeView, self).rowsRemoved(parent, start, end)
@@ -1304,9 +1301,9 @@ class TreeView(qt.QTreeView):
         Reimplementation of the QTreeView.rowsInserted. Opens all persistent
         editors under parent.
 
-        :param parent:
-        :param start:
-        :param end:
+        :param parent: parent item
+        :param start: starting new item
+        :param end: ending new item
         """
         self.__openPersistentEditors(parent, False)
         super(TreeView, self).rowsInserted(parent, start, end)

--- a/silx/gui/plot3d/ScalarFieldView.py
+++ b/silx/gui/plot3d/ScalarFieldView.py
@@ -788,8 +788,7 @@ class ScalarFieldView(Plot3DWindow):
         """
         Saves this view state. Only isosurfaces at the moment. Does not save
         the isosurface's function.
-        :param ioDevice:
-        :return:
+        :param ioDevice: the device targetted for writting
         """
 
         stream = qt.QDataStream(ioDevice)
@@ -829,8 +828,7 @@ class ScalarFieldView(Plot3DWindow):
         """
         Loads this view state.
         See ScalarFieldView.saveView to know what is supported at the moment.
-        :param ioDevice:
-        :return:
+        :param ioDevice: the device targetted for reading
         """
 
         tagStack = deque()

--- a/silx/gui/plot3d/scene/function.py
+++ b/silx/gui/plot3d/scene/function.py
@@ -214,7 +214,7 @@ class DirectionalLight(event.Notifier, ProgramFunction):
 
     @property
     def isOn(self):
-        """True is light is on, False otherwise."""
+        """True if light is on, False otherwise."""
         return self._isOn and self._direction is not None
 
     @isOn.setter


### PR DESCRIPTION
No issue with code or user API for me. Just one remark which might be important (that we saw with @vallsv) :

    It's looks like the PlaneOrientationItem is not taking into account the name of the axes setted by the user
    in PlaneOrientationItem you have : 
    "
        _PLANE_ACTIONS = (
            ('3d-plane-normal-x', 'YZ-Plane',
             'Set plane perpendicular to X axis', (1., 0., 0.)),
            ('3d-plane-normal-y', 'XZ-Plane',
             'Set plane perpendicular to Y axis', (0., 1., 0.)),
            ('3d-plane-normal-z', 'XY-Plane',
             'Set plane perpendicular to Z axis', (0., 0., 1.)),
        )
    "
    
    And in the example (examples/viewer3DVolume) if you set different axis names like: "window.setAxesLabels('Y', 'X', 'Z')" you can end up with some misleading information.

Some cosmetic optimisation which would be nice from my point of view but no urgency: 

   - update camera view position icon : it would be nice to get something more "main stream" with an eye or a camera and the field of view
   - viewer3d example (also from @vallsv ) : 
        - adding and deleting an isosurface (+ - buttons) would be better slightly move to the right (under level and color items) from @vallsv
        - double click on the isosurface level : 
                + reset it to 0
                + launch probably a subroutine and don't wait for validation
                + don't reset the QSlider value of the iso level
        - transparency : It would be nice to an information about the setted value (and min and max)

To end some more general question about the structure :

    - Isosurface might be in an independent file ? 
    - would  it be interesting to create a geometry module (under plot3d) (including for example transform, scane.utils, primitives...)
    - some functions might also be needed somewhere else (like angleBetweenVectors, segmentPlaneIntersect, Plane ...) and generate an higher module (under silx )
